### PR TITLE
prefer tomllib from the Standard Library on Python >= 3.11

### DIFF
--- a/tests/_test_version.py
+++ b/tests/_test_version.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-import toml
+try:
+    # 'tomllib' is in the standard Library since Python 3.11
+    import tomllib as toml
+except ImportError:
+    import toml
+
 from django.test import TestCase
 
 import drf_yaml


### PR DESCRIPTION
I don't know how to reflect this in pyproject.toml

Actualy `tomllib` = `tomli` but here it does not mather.

https://wiki.debian.org/Python/Backports
